### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       #-/path/to/key:/path/to/key
     ports:
       - "10086:10086"
-    # command: ["v2ray","-config=https://xxx.com"]
+    # command: ["v2ray","run","-config=https://xxx.com"]
 
   v2scar:
     container_name: v2scar


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore